### PR TITLE
Fix closing </a> for header if no logo is provided

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,8 +5,9 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-transparent">
       <a class="navbar-brand" href="{{ site.BaseURL }}">
         {{ with site.Params.logo}}
-        <img width="{{site.Params.logo_width}}" class="img-fluid" src="{{ . | absURL }}" alt="{{ site.Title }}"></a>
+        <img width="{{site.Params.logo_width}}" class="img-fluid" src="{{ . | absURL }}" alt="{{ site.Title }}">
         {{ else }}{{site.Title}}{{end}}
+      </a>
       <button class="navbar-toggler border-0" type="button" data-toggle="collapse" data-target="#navigation">
         <i class="ti-menu h3"></i>
       </button>


### PR DESCRIPTION
The opening tag is before the `{{ with ...}}` block, so we need to make sure we have the closing tag outside of the block. 
Otherwise the HTML is broken if no logo is given.