### PR TITLE
Add empty scss stylesheet for projects to extend

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1,0 +1,2 @@
+// This file is empty within the template
+// You can use it to override CSS from within your project

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -22,3 +22,5 @@ VERSION:	Versoin Number
 @import 'templates/navigation.scss';
 
 @import 'templates/main.scss';
+
+@import 'custom';


### PR DESCRIPTION
Having a scss style sheet file, that is guranteed empty within the
template, allows projects to add aditional style definitions in a clean
and updatefriendly way.