### PR TITLE
Allow the user scale the viewport

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
   <title>{{ .Title }}</title>
 
   {{ "<!-- mobile responsive meta -->" | safeHTML }}
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
   <meta name="description" content="{{ with .Params.Description }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}">
   {{ with site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
   {{ hugo.Generator }}


### PR DESCRIPTION
Disabling zooming is problematic for users with low vision who rely on
screen magnification to properly see the contents of a web page.

Learn more: [https://web.dev/meta-viewport/](https://web.dev/meta-viewport/)