### PR TITLE
Make headings of footer navigation configurable

### DIFF
--- a/assets/scss/_typography.scss
+++ b/assets/scss/_typography.scss
@@ -22,12 +22,12 @@ small {
   font-size: 88%;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, .h1,
+h2, .h2,
+h3, .h3,
+h4, .h4,
+h5, .h5,
+h6, .h6 {
   color: $text-color-dark;
   font-family: $primary-font;
   font-weight: 700;

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -58,43 +58,43 @@ name = "FAQ"
 URL = "faq"
 weight = 4
 
-# company 
-[[menu.company]]
+# footer menu left
+[[menu.footer_left]]
 name = "About Us"
 URL = "#"
 
-[[menu.company]]
+[[menu.footer_left]]
 name = "Quick Start"
 URL = "#"
 
-[[menu.company]]
+[[menu.footer_left]]
 name = "Pricing"
 URL = "pricing"
 
 
-# Product 
-[[menu.product]]
+# footer menu middle
+[[menu.footer_middle]]
 name = "Pricing"
 URL = "pricing"
 
-[[menu.product]]
+[[menu.footer_middle]]
 name = "Platform"
 URL = "#"
 
-[[menu.product]]
+[[menu.footer_middle]]
 name = "Features"
 URL = "#"
 
-# Support 
-[[menu.support]]
+# footer menu right
+[[menu.footer_right]]
 name = "Privacy Policy"
 URL = "privacy-policy"
 
-[[menu.support]]
+[[menu.footer_right]]
 name = "Terms & Conditions"
 URL = "terms-conditions"
 
-[[menu.support]]
+[[menu.footer_right]]
 name = "FAQ"
 URL = "faq"
 
@@ -109,6 +109,9 @@ author = "Themefisher"
 contact_form_action = "#" # contact form works with https://formspree.io
 
 ########### footer content ##########
+footer_menu_left = "Company"
+footer_menu_middle = "Product"
+footer_menu_right = "Support"
 footer_content = "Lorem ipsum dolor sit amet, consectetur elit. Consjat tristique eget amet, tempus eu at cttur."
 # copyright
 copyright = "Design By [Themefisher](https://themefisher.com/) Develop By [Gethugothemes](https://gethugothemes.com/)"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,30 +2,30 @@
   <div class="container">
     <div class="row">
       <div class="col-md-3 col-sm-6 mb-5">
-        {{ if site.Menus.company }}
-        <h3 class="mb-4">Company</h3>
+        {{ if site.Menus.footer_left }}
+        <h3 class="mb-4">{{ site.Params.footer_menu_left }}</h3>
         <ul class="list-unstyled footer-list">
-          {{ range site.Menus.company }}
+          {{ range site.Menus.footer_left }}
           <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
           {{ end }}
         </ul>
         {{ end }}
       </div>
       <div class="col-md-3 col-sm-6 mb-5">
-        {{ if site.Menus.product }}
-        <h3 class="mb-4">Product</h3>
+        {{ if site.Menus.footer_middle }}
+        <h3 class="mb-4">{{ site.Params.footer_menu_middle }}</h3>
         <ul class="list-unstyled footer-list">
-          {{ range site.Menus.product }}
+          {{ range site.Menus.footer_middle }}
           <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
           {{ end }}
         </ul>
         {{ end }}
       </div>
       <div class="col-md-3 col-sm-6 mb-5">
-        {{ if site.Menus.support }}
-        <h3 class="mb-4">Support</h3>
+        {{ if site.Menus.footer_right }}
+        <h3 class="mb-4">{{ site.Params.footer_menu_right }}</h3>
         <ul class="list-unstyled footer-list">
-          {{ range site.Menus.support }}
+          {{ range site.Menus.footer_right }}
           <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
           {{ end }}
         </ul>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-3 col-sm-6 mb-5">
         {{ if site.Menus.footer_left }}
-        <h3 class="mb-4">{{ site.Params.footer_menu_left }}</h3>
+        <div class="h3 mb-4">{{ site.Params.footer_menu_left }}</div>
         <ul class="list-unstyled footer-list">
           {{ range site.Menus.footer_left }}
           <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
@@ -13,7 +13,7 @@
       </div>
       <div class="col-md-3 col-sm-6 mb-5">
         {{ if site.Menus.footer_middle }}
-        <h3 class="mb-4">{{ site.Params.footer_menu_middle }}</h3>
+        <div class="h3 mb-4">{{ site.Params.footer_menu_middle }}</div>
         <ul class="list-unstyled footer-list">
           {{ range site.Menus.footer_middle }}
           <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
@@ -23,7 +23,7 @@
       </div>
       <div class="col-md-3 col-sm-6 mb-5">
         {{ if site.Menus.footer_right }}
-        <h3 class="mb-4">{{ site.Params.footer_menu_right }}</h3>
+        <div class="h3 mb-4">{{ site.Params.footer_menu_right }}</div>
         <ul class="list-unstyled footer-list">
           {{ range site.Menus.footer_right }}
           <li><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>


### PR DESCRIPTION
This commit introduces three new site variables:

 * footer_menu_left = "Company"
 * footer_menu_middle = "Product"
 * footer_menu_right = "Support"

That makes it possible the define the headings of the subnavigations in
the footer user definable.

In addition the navigations where renamed to be more descriptive.