### PR TITLE
Use article image instead of default OGP image

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,11 +22,11 @@
   <link rel="icon" href="{{ `images/favicon.png` | absURL }}" type="image/x-icon">
 
   
-  {{ with .Params.Image }}
-  <meta property="og:image" content="{{ . | absURL }}" />
-  {{ end }}
   {{ template "_internal/opengraph.html" . }}
   {{ template "_internal/google_analytics.html" . }}
   {{ template "_internal/google_analytics_async.html" . }}
+  {{ with .Params.Image }}
+  <meta property="og:image" content="{{ . | absURL }}" />
+  {{ end }}
   
 </head>


### PR DESCRIPTION
This PR makes article image overrides default OGP image. 

https://gohugo.io/templates/internal/#open-graph