### PR TITLE
Spelling correction

### DIFF
--- a/exampleSite/content/english/privacy-policy/_index.md
+++ b/exampleSite/content/english/privacy-policy/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Privecy & Policy"
+title: "Privacy & Policy"
 subtitle: ""
 # meta description
 description: "This is meta description"


### PR DESCRIPTION
Correct spelling of privacy from "Privecy" to "Privacy"